### PR TITLE
feat: Avalonia GUI — tray icon + avatar window with push-to-talk

### DIFF
--- a/src/CopilotVoice/App.axaml
+++ b/src/CopilotVoice/App.axaml
@@ -1,0 +1,7 @@
+<Application xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="CopilotVoice.App">
+    <Application.Styles>
+        <FluentTheme />
+    </Application.Styles>
+</Application>

--- a/src/CopilotVoice/App.axaml.cs
+++ b/src/CopilotVoice/App.axaml.cs
@@ -1,0 +1,106 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Markup.Xaml;
+using CopilotVoice.Views;
+
+namespace CopilotVoice;
+
+public class App : Application
+{
+    private AvatarWindow? _avatarWindow;
+    private AppServices? _services;
+
+    public override void Initialize()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+
+    public override void OnFrameworkInitializationCompleted()
+    {
+        if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
+        {
+            // No main window — tray icon app
+            desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
+
+            _services = new AppServices();
+
+            // Create and show the avatar window
+            _avatarWindow = new AvatarWindow();
+            _avatarWindow.SetServices(_services);
+            _avatarWindow.Show();
+
+            // Setup tray icon
+            var trayIcon = new TrayIcon
+            {
+                ToolTipText = "Copilot Voice",
+                IsVisible = true,
+                Menu = BuildTrayMenu(desktop)
+            };
+
+            // Set tray icon text (emoji-style isn't supported, use a simple icon)
+            trayIcon.Clicked += (_, _) =>
+            {
+                if (_avatarWindow.IsVisible)
+                    _avatarWindow.Hide();
+                else
+                    _avatarWindow.Show();
+            };
+
+            // Update tray tooltip based on state
+            _services.OnStateChanged += state =>
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                    trayIcon.ToolTipText = $"Copilot Voice — {state}");
+
+            // Start all services
+            _ = _services.StartAsync();
+        }
+
+        base.OnFrameworkInitializationCompleted();
+    }
+
+    private NativeMenu BuildTrayMenu(IClassicDesktopStyleApplicationLifetime desktop)
+    {
+        var menu = new NativeMenu();
+
+        var showItem = new NativeMenuItem("Show Avatar");
+        showItem.Click += (_, _) => _avatarWindow?.Show();
+        menu.Add(showItem);
+
+        var hideItem = new NativeMenuItem("Hide Avatar");
+        hideItem.Click += (_, _) => _avatarWindow?.Hide();
+        menu.Add(hideItem);
+
+        menu.Add(new NativeMenuItemSeparator());
+
+        if (_services != null)
+        {
+            var sessionsItem = new NativeMenuItem("Sessions") { Menu = new NativeMenu() };
+            _services.OnSessionsRefreshed += sessions =>
+            {
+                Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                {
+                    sessionsItem.Menu!.Items.Clear();
+                    foreach (var s in sessions)
+                    {
+                        var item = new NativeMenuItem(
+                            $"{(s.IsFocused ? "● " : "○ ")}{s.Label}");
+                        sessionsItem.Menu.Items.Add(item);
+                    }
+                });
+            };
+            menu.Add(sessionsItem);
+            menu.Add(new NativeMenuItemSeparator());
+        }
+
+        var quitItem = new NativeMenuItem("Quit");
+        quitItem.Click += (_, _) =>
+        {
+            _services?.Dispose();
+            desktop.Shutdown();
+        };
+        menu.Add(quitItem);
+
+        return menu;
+    }
+}

--- a/src/CopilotVoice/AppServices.cs
+++ b/src/CopilotVoice/AppServices.cs
@@ -1,0 +1,254 @@
+using CopilotVoice.Audio;
+using CopilotVoice.Config;
+using CopilotVoice.Input;
+using CopilotVoice.Messaging;
+using CopilotVoice.Sessions;
+using CopilotVoice.UI.Avatar;
+
+namespace CopilotVoice;
+
+/// <summary>
+/// Centralizes all backend services and exposes events for the Avalonia UI.
+/// </summary>
+public sealed class AppServices : IDisposable
+{
+    public AppConfig Config { get; }
+    public AvatarState AvatarState { get; } = new();
+    public AvatarAnimator Animator { get; } = new();
+
+    private readonly ConfigManager _configManager;
+    private readonly SessionDetector _sessionDetector;
+    private readonly SessionManager _sessionManager;
+    private PushToTalkRecognizer? _stt;
+    private TextToSpeechEngine? _tts;
+    private IInputSender? _inputSender;
+    private MessageListener? _messageListener;
+    private Hotkey.HotkeyListener? _hotkey;
+    private bool _isRecording;
+    private bool _disposed;
+
+    // UI events
+    public event Action<string>? OnStateChanged;
+    public event Action<string?, string?>? OnSpeechBubble;
+    public event Action<string?>? OnTargetSession;
+    public event Action<string?, TimeSpan>? OnTimerTick;
+    public event Action<List<CopilotSession>>? OnSessionsRefreshed;
+    public event Action<string>? OnLog;
+
+    public AppServices()
+    {
+        _configManager = new ConfigManager();
+        Config = _configManager.LoadOrCreate();
+
+        // Apply env var overrides
+        var envKey = Environment.GetEnvironmentVariable("AZURE_SPEECH_KEY");
+        var envRegion = Environment.GetEnvironmentVariable("AZURE_SPEECH_REGION");
+        if (!string.IsNullOrEmpty(envKey))
+        {
+            Config.AzureSpeechKey = envKey;
+            Config.AuthMode = AuthMode.Env;
+        }
+        if (!string.IsNullOrEmpty(envRegion))
+            Config.AzureSpeechRegion = envRegion;
+
+        _sessionDetector = new SessionDetector();
+        _sessionManager = new SessionManager(_sessionDetector);
+    }
+
+    public async Task StartAsync()
+    {
+        Log("Starting services...");
+
+        // Auth check
+        var auth = new AzureAuthProvider();
+        try
+        {
+            var (_, region) = auth.Resolve(Config);
+            Log($"Azure Speech: {region}");
+        }
+        catch (Exception ex)
+        {
+            Log($"Auth failed: {ex.Message}");
+            OnStateChanged?.Invoke("Error");
+            return;
+        }
+
+        // Sessions
+        var sessions = _sessionDetector.DetectSessions();
+        Log($"Found {sessions.Count} session(s)");
+        OnSessionsRefreshed?.Invoke(sessions);
+
+        _sessionManager.OnTargetChanged += s =>
+        {
+            OnTargetSession?.Invoke(s?.Label);
+            Log($"Target: {s?.Label ?? "none"}");
+        };
+        _sessionManager.StartWatching();
+
+        // Input sender
+        try
+        {
+            _inputSender = InputSenderFactory.Create();
+            Log($"Input sender: {_inputSender.GetType().Name}");
+        }
+        catch (Exception ex)
+        {
+            Log($"Input sender: {ex.Message}");
+        }
+
+        // TTS
+        if (Config.EnableVoiceOutput)
+        {
+            try
+            {
+                _tts = new TextToSpeechEngine(Config);
+                _tts.OnSpeechStarted += () =>
+                {
+                    Animator.RecordInteraction();
+                    OnStateChanged?.Invoke("Speaking");
+                };
+                _tts.OnSpeechFinished += () => OnStateChanged?.Invoke("Ready");
+                _tts.OnError += err => Log($"TTS error: {err}");
+                Log($"TTS: {Config.VoiceName}");
+            }
+            catch (Exception ex)
+            {
+                Log($"TTS init failed: {ex.Message}");
+            }
+        }
+
+        // STT
+        _stt = new PushToTalkRecognizer(Config);
+        _stt.OnPartialResult += text =>
+        {
+            Animator.RecordInteraction();
+            OnSpeechBubble?.Invoke(text, null);
+        };
+        _stt.OnError += err => Log($"STT error: {err}");
+        _stt.OnLog += msg => Log(msg);
+
+        // Message listener
+        try
+        {
+            _messageListener = new MessageListener();
+            _messageListener.OnMessageReceived += async msg =>
+            {
+                if (_tts != null)
+                {
+                    OnSpeechBubble?.Invoke(msg.Text, msg.SessionLabel);
+                    await _tts.SpeakAsync(msg.Text);
+                    OnSpeechBubble?.Invoke(null, null);
+                }
+            };
+            _messageListener.Start();
+            Log("Message listener: localhost:7701");
+        }
+        catch (Exception ex)
+        {
+            Log($"Message listener: {ex.Message}");
+        }
+
+        // Hotkey
+        try
+        {
+            _hotkey = new Hotkey.HotkeyListener(Config.Hotkey);
+            _hotkey.OnError += msg => Log($"Hotkey: {msg}");
+            _hotkey.OnPushToTalkStart += OnHotkeyDown;
+            _hotkey.OnPushToTalkStop += OnHotkeyUp;
+            _hotkey.Start();
+            Log($"Hotkey: {Config.Hotkey}");
+        }
+        catch (Exception ex)
+        {
+            Log($"Hotkey failed: {ex.Message}");
+        }
+
+        // Start avatar idle animation
+        Animator.StartIdleLoop();
+        OnStateChanged?.Invoke("Ready");
+        Log("Ready!");
+    }
+
+    private async void OnHotkeyDown()
+    {
+        if (_isRecording || _stt == null) return;
+        _isRecording = true;
+
+        Log("Hotkey pressed — starting recording");
+        OnStateChanged?.Invoke("Recording");
+        Animator.RecordInteraction();
+
+        try
+        {
+            await _stt.StartRecordingAsync();
+        }
+        catch (Exception ex)
+        {
+            Log($"Mic error: {ex.Message}");
+            OnStateChanged?.Invoke("Error");
+            _isRecording = false;
+        }
+    }
+
+    private async void OnHotkeyUp()
+    {
+        if (!_isRecording || _stt == null) return;
+        _isRecording = false;
+
+        Log("Hotkey released — stopping recording");
+        OnStateChanged?.Invoke("Transcribing");
+
+        try
+        {
+            var text = await _stt.StopRecordingAndTranscribeAsync();
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                Log("No speech detected");
+                OnStateChanged?.Invoke("Ready");
+                return;
+            }
+
+            Log($"Transcribed: {text}");
+
+            // Send to target session
+            var target = _sessionManager.GetTargetSession();
+            if (target != null && _inputSender != null)
+            {
+                await _inputSender.SendTextAsync(target, text, Config.AutoPressEnter);
+                Log($"Sent to {target.Label}");
+                OnSpeechBubble?.Invoke(text, target.Label);
+                await Task.Delay(2000);
+                OnSpeechBubble?.Invoke(null, null);
+            }
+            else
+            {
+                Log("No target session");
+            }
+
+            OnStateChanged?.Invoke("Ready");
+        }
+        catch (Exception ex)
+        {
+            Log($"Error: {ex.Message}");
+            OnStateChanged?.Invoke("Error");
+        }
+    }
+
+    private void Log(string msg)
+    {
+        Console.Error.WriteLine($"[copilot-voice] {msg}");
+        OnLog?.Invoke(msg);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _hotkey?.Dispose();
+        Animator.Dispose();
+        _stt?.Dispose();
+        _tts?.Dispose();
+        _sessionManager.Dispose();
+        _messageListener?.Dispose();
+    }
+}

--- a/src/CopilotVoice/Views/AvatarWindow.axaml
+++ b/src/CopilotVoice/Views/AvatarWindow.axaml
@@ -1,0 +1,68 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="CopilotVoice.Views.AvatarWindow"
+        Title="🤖 Copilot Voice"
+        Width="280" Height="420"
+        CanResize="False"
+        SystemDecorations="Full"
+        WindowStartupLocation="Manual"
+        Background="#1E1E2E"
+        Topmost="True">
+
+    <Grid RowDefinitions="Auto,*,Auto,Auto,Auto">
+
+        <!-- Header -->
+        <Border Grid.Row="0" Padding="12,8" Background="#2D2D44">
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="🤖" FontSize="18" VerticalAlignment="Center"/>
+                <TextBlock Text="Copilot Voice" FontSize="14" FontWeight="Bold"
+                           Foreground="#CDD6F4" VerticalAlignment="Center"/>
+                <TextBlock x:Name="StatusBadge" Text="● Starting..." FontSize="11"
+                           Foreground="#F9E2AF" VerticalAlignment="Center" Margin="8,0,0,0"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Avatar Face -->
+        <Border Grid.Row="1" Padding="8" HorizontalAlignment="Center" VerticalAlignment="Center">
+            <TextBlock x:Name="AvatarFace"
+                       FontFamily="Cascadia Mono, Menlo, Monaco, monospace"
+                       FontSize="20"
+                       Foreground="#CDD6F4"
+                       TextAlignment="Center"
+                       HorizontalAlignment="Center"
+                       LineHeight="26"
+                       Text="  ◠◠◠  &#10; ┌─────┐&#10; │ ◕ ◕ │&#10; │  ‿  │&#10; └─────┘"/>
+        </Border>
+
+        <!-- Speech Bubble / Session -->
+        <Border Grid.Row="2" Padding="12,6" Background="#313244" CornerRadius="6" Margin="12,0">
+            <StackPanel Spacing="2">
+                <TextBlock x:Name="SessionLabel" Text="📂 waiting..."
+                           FontSize="11" Foreground="#94A3B8"/>
+                <TextBlock x:Name="SpeechBubble" Text=""
+                           FontSize="12" Foreground="#CDD6F4" TextWrapping="Wrap"
+                           MaxHeight="40"/>
+            </StackPanel>
+        </Border>
+
+        <!-- Log area -->
+        <Border Grid.Row="3" Padding="8,4" Background="#181825" Margin="12,4" CornerRadius="4">
+            <ScrollViewer Height="60">
+                <TextBlock x:Name="LogArea" Text="" FontSize="9"
+                           FontFamily="Cascadia Mono, Menlo, Monaco, monospace"
+                           Foreground="#6C7086" TextWrapping="Wrap"/>
+            </ScrollViewer>
+        </Border>
+
+        <!-- Timer / Status Bar -->
+        <Border Grid.Row="4" Padding="12,8" Background="#2D2D44" Margin="0,0,0,0">
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock x:Name="HotkeyLabel" Text="⌨️ Ctrl+Shift+V"
+                           FontSize="11" Foreground="#6C7086" VerticalAlignment="Center"/>
+                <TextBlock x:Name="TimerLabel" Grid.Column="1" Text=""
+                           FontSize="11" Foreground="#F9E2AF" VerticalAlignment="Center"/>
+            </Grid>
+        </Border>
+
+    </Grid>
+</Window>

--- a/src/CopilotVoice/Views/AvatarWindow.axaml.cs
+++ b/src/CopilotVoice/Views/AvatarWindow.axaml.cs
@@ -1,0 +1,107 @@
+using Avalonia.Controls;
+using Avalonia.Threading;
+using CopilotVoice.UI.Avatar;
+
+namespace CopilotVoice.Views;
+
+public partial class AvatarWindow : Window
+{
+    private AppServices? _services;
+    private IAvatarTheme? _theme;
+
+    public AvatarWindow()
+    {
+        InitializeComponent();
+
+        // Position bottom-right of screen
+        Opened += (_, _) =>
+        {
+            var screen = Screens.Primary;
+            if (screen != null)
+            {
+                var workArea = screen.WorkingArea;
+                Position = new Avalonia.PixelPoint(
+                    (int)(workArea.Right - Width - 20),
+                    (int)(workArea.Bottom - Height - 20));
+            }
+        };
+    }
+
+    public void SetServices(AppServices services)
+    {
+        _services = services;
+        _theme = services.AvatarState.GetThemeRenderer();
+
+        services.Animator.OnExpressionChanged += expr =>
+            Dispatcher.UIThread.Post(() => UpdateFace(expr));
+
+        services.OnStateChanged += state =>
+            Dispatcher.UIThread.Post(() => UpdateStatus(state));
+
+        services.OnSpeechBubble += (text, label) =>
+            Dispatcher.UIThread.Post(() =>
+            {
+                SpeechBubble.Text = string.IsNullOrEmpty(text) ? "" : $"💬 {text}";
+                if (!string.IsNullOrEmpty(label))
+                    SessionLabel.Text = $"📂 {label}";
+            });
+
+        services.OnTargetSession += label =>
+            Dispatcher.UIThread.Post(() =>
+                SessionLabel.Text = $"📂 {label ?? "no session"}");
+
+        services.OnTimerTick += (phase, remaining) =>
+            Dispatcher.UIThread.Post(() =>
+            {
+                if (phase == null)
+                    TimerLabel.Text = "";
+                else
+                {
+                    var icon = phase == "Work" ? "🔨" : "☕";
+                    TimerLabel.Text = $"{icon} {phase} {remaining:mm\\:ss}";
+                }
+            });
+
+        services.OnLog += msg =>
+            Dispatcher.UIThread.Post(() => AppendLog(msg));
+
+        // Show hotkey
+        HotkeyLabel.Text = $"⌨️ {services.Config.Hotkey}";
+    }
+
+    private void UpdateFace(AvatarExpression expression)
+    {
+        if (_theme == null) return;
+        var lines = _theme.RenderFrame(expression);
+        AvatarFace.Text = string.Join("\n", lines);
+    }
+
+    private void UpdateStatus(string state)
+    {
+        StatusBadge.Text = state switch
+        {
+            "Recording" => "🔴 Recording",
+            "Transcribing" => "⏳ Transcribing",
+            "Speaking" => "🔊 Speaking",
+            "Error" => "⚠️ Error",
+            _ => "● Ready"
+        };
+
+        StatusBadge.Foreground = state switch
+        {
+            "Recording" => Avalonia.Media.Brushes.Red,
+            "Error" => Avalonia.Media.Brushes.Orange,
+            _ => Avalonia.Media.Brushes.LightGreen
+        };
+    }
+
+    private void AppendLog(string msg)
+    {
+        var existing = LogArea.Text ?? "";
+        var lines = existing.Split('\n');
+        // Keep last 8 lines
+        if (lines.Length > 8)
+            existing = string.Join('\n', lines[^8..]);
+        LogArea.Text = string.IsNullOrEmpty(existing) ? msg : $"{existing}\n{msg}";
+    }
+}


### PR DESCRIPTION
Replaces the console app with a proper Avalonia desktop GUI.

- **Tray icon** in menu bar with Show/Hide, Sessions, Quit
- **Avatar window**: dark themed, robot face, speech bubble, session label, log panel
- **Full pipeline working**: Hotkey → STT → Transcribe → Send to session
- **Detailed STT logging** visible in avatar window log panel
- **Always-on-top** floating window, positioned bottom-right

Closes #31, Closes #32