### PR TITLE
fix: session targeting and input sender

### DIFF
--- a/src/CopilotVoice/AppServices.cs
+++ b/src/CopilotVoice/AppServices.cs
@@ -214,6 +214,7 @@ public sealed class AppServices : IDisposable
             var target = _sessionManager.GetTargetSession();
             if (target != null && _inputSender != null)
             {
+                Log($"Sending to {target.Label} (PID:{target.ProcessId}, app:{target.TerminalApp})");
                 await _inputSender.SendTextAsync(target, text, Config.AutoPressEnter);
                 Log($"Sent to {target.Label}");
                 OnSpeechBubble?.Invoke(text, target.Label);
@@ -222,7 +223,7 @@ public sealed class AppServices : IDisposable
             }
             else
             {
-                Log("No target session");
+                Log($"No target session (target={target?.Label}, sender={_inputSender?.GetType().Name})");
             }
 
             OnStateChanged?.Invoke("Ready");

--- a/src/CopilotVoice/Input/MacInputSender.cs
+++ b/src/CopilotVoice/Input/MacInputSender.cs
@@ -44,15 +44,12 @@ public class MacInputSender : IInputSender
             return $"tell application \"iTerm2\" to tell current session of current window to write text \"{escapedText}\"{enterClause}";
         }
 
-        // Default: Terminal.app — use "do script" which auto-appends a newline
+        // Default: Terminal.app
         if (pressEnter)
         {
-            return string.IsNullOrEmpty(session.Id)
-                ? $"tell application \"Terminal\" to do script \"{escapedText}\" in front window"
-                : $"tell application \"Terminal\" to do script \"{escapedText}\" in window id {session.Id}";
+            return $"tell application \"Terminal\" to do script \"{escapedText}\" in front window";
         }
 
-        // Without Enter we use keystroke injection instead
         return $"tell application \"System Events\" to keystroke \"{escapedText}\"";
     }
 

--- a/src/CopilotVoice/Sessions/SessionManager.cs
+++ b/src/CopilotVoice/Sessions/SessionManager.cs
@@ -40,6 +40,16 @@ public class SessionManager : IDisposable
 
     public void StartWatching(int pollIntervalMs = 500)
     {
+        // Default to first available session if none set
+        if (_currentTarget == null)
+        {
+            var sessions = _detector.GetCachedSessions();
+            if (sessions.Count == 0)
+                sessions = _detector.DetectSessions();
+            if (sessions.Count > 0)
+                UpdateTarget(sessions[0]);
+        }
+
         _watchCts = new CancellationTokenSource();
         _ = WatchLoopAsync(pollIntervalMs, _watchCts.Token);
     }


### PR DESCRIPTION
Fixes 'No target session' — SessionManager now defaults to first detected session. MacInputSender uses front window instead of invalid window IDs. Adds detailed STT logging.