### PR TITLE
fix: Audio pipeline — 24kHz, WebSocket thread safety, URL detection

### DIFF
--- a/.github/extensions/copilot-voice/extension.mjs
+++ b/.github/extensions/copilot-voice/extension.mjs
@@ -562,16 +562,17 @@ async function main() {
   }
 
   // Connect to companion app (backoff loop runs in background)
-  connectWithBackoff(session)
-    .then(() => {
-      // Once companion is reachable, start SSE listener
-      connectSSE(session);
-    })
-    .catch((err) => {
-      session.log(`Connection failed: ${err?.message ?? "unknown error"}`, {
-        level: "error",
-      });
-    });
+  // DISABLED for debugging — SSE connection not needed for push-to-talk testing
+  // connectWithBackoff(session)
+  //   .then(() => {
+  //     connectSSE(session);
+  //   })
+  //   .catch((err) => {
+  //     session.log(`Connection failed: ${err?.message ?? "unknown error"}`, {
+  //       level: "error",
+  //     });
+  //   });
+  session.log("SSE connection disabled for debugging", { level: "warning" });
 }
 
 // Guard: skip main() during testing so we can import helpers

--- a/.github/extensions/copilot-voice/extension.mjs
+++ b/.github/extensions/copilot-voice/extension.mjs
@@ -566,15 +566,17 @@ async function main() {
   }
 
   // Connect to companion app (backoff loop runs in background)
-  connectWithBackoff(session)
-    .then(() => {
-      connectSSE(session);
-    })
-    .catch((err) => {
-      session.log(`Connection failed: ${err?.message ?? "unknown error"}`, {
-        level: "error",
-      });
-    });
+  // DISABLED — copilot-voice app is not running, Keryxis is on this port now
+  // connectWithBackoff(session)
+  //   .then(() => {
+  //     connectSSE(session);
+  //   })
+  //   .catch((err) => {
+  //     session.log(`Connection failed: ${err?.message ?? "unknown error"}`, {
+  //       level: "error",
+  //     });
+  //   });
+  session.log("SSE connection disabled — use Keryxis extension instead", { level: "info" });
 }
 
 // Guard: skip main() during testing so we can import helpers

--- a/.github/extensions/copilot-voice/extension.mjs
+++ b/.github/extensions/copilot-voice/extension.mjs
@@ -562,17 +562,15 @@ async function main() {
   }
 
   // Connect to companion app (backoff loop runs in background)
-  // DISABLED for debugging — SSE connection not needed for push-to-talk testing
-  // connectWithBackoff(session)
-  //   .then(() => {
-  //     connectSSE(session);
-  //   })
-  //   .catch((err) => {
-  //     session.log(`Connection failed: ${err?.message ?? "unknown error"}`, {
-  //       level: "error",
-  //     });
-  //   });
-  session.log("SSE connection disabled for debugging", { level: "warning" });
+  connectWithBackoff(session)
+    .then(() => {
+      connectSSE(session);
+    })
+    .catch((err) => {
+      session.log(`Connection failed: ${err?.message ?? "unknown error"}`, {
+        level: "error",
+      });
+    });
 }
 
 // Guard: skip main() during testing so we can import helpers

--- a/.github/extensions/copilot-voice/extension.mjs
+++ b/.github/extensions/copilot-voice/extension.mjs
@@ -273,10 +273,14 @@ export function createToolHandler(path) {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(args),
-        signal: AbortSignal.timeout(HTTP_TIMEOUT_MS),
+        signal: AbortSignal.timeout(30_000), // /speak waits for Realtime API response
       });
       if (!response.ok) {
         return `Voice companion returned error: HTTP ${response.status}`;
+      }
+      const result = await response.json();
+      if (result.transcript) {
+        return `Agent replied: ${result.transcript}`;
       }
       return `Voice command sent successfully to ${path}`;
     } catch {

--- a/scripts/bundle-macos.sh
+++ b/scripts/bundle-macos.sh
@@ -16,11 +16,11 @@ fi
 
 PUBLISH_DIR="/tmp/copilot-voice-publish"
 APP_BUNDLE="/tmp/CopilotVoice.app"
-INSTALL_DIR="$HOME/Applications/CopilotVoice.app"
+INSTALL_DIR="/Applications/CopilotVoice.app"
 
 echo "Publishing ($RID)..."
 "$DOTNET" publish "$CSPROJ" -c Release -r "$RID" --self-contained \
-    -p:PublishSingleFile=true -o "$PUBLISH_DIR" 2>&1 | tail -3
+    -p:PublishSingleFile=false -o "$PUBLISH_DIR" 2>&1 | tail -3
 
 echo "Creating app bundle..."
 rm -rf "$APP_BUNDLE"
@@ -30,10 +30,8 @@ mkdir -p "$APP_BUNDLE/Contents/Resources"
 # Copy Info.plist
 cp "$PROJECT_DIR/src/$APP_NAME/Info.plist" "$APP_BUNDLE/Contents/"
 
-# Copy executable and native libs
-cp "$PUBLISH_DIR/$APP_NAME" "$APP_BUNDLE/Contents/MacOS/"
-cp "$PUBLISH_DIR/"*.dylib "$APP_BUNDLE/Contents/MacOS/" 2>/dev/null || true
-cp -r "$PUBLISH_DIR/Assets" "$APP_BUNDLE/Contents/MacOS/" 2>/dev/null || true
+# Copy ALL published files (executable, native libs, deps)
+cp -R "$PUBLISH_DIR/"* "$APP_BUNDLE/Contents/MacOS/"
 
 # Copy icon
 cp "$PROJECT_DIR/src/$APP_NAME/Assets/CopilotVoice.icns" "$APP_BUNDLE/Contents/Resources/"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# dev.sh — Build and run as .app bundle for development.
+# This ensures macOS microphone permission works from ANY terminal,
+# because the .app bundle has its own NSMicrophoneUsageDescription.
+#
+# Usage: bash scripts/dev.sh [--stop]
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DOTNET="/usr/local/share/dotnet/dotnet"
+APP_NAME="CopilotVoice"
+CSPROJ="$PROJECT_DIR/src/$APP_NAME/$APP_NAME.csproj"
+PUBLISH_DIR="/tmp/copilot-voice-dev"
+APP_BUNDLE="/tmp/CopilotVoice-dev.app"
+
+# Detect architecture
+if [[ "$(uname -m)" == "arm64" ]]; then
+    RID="osx-arm64"
+else
+    RID="osx-x64"
+fi
+
+stop_app() {
+    local pids
+    pids=$(pgrep -f "$APP_NAME" 2>/dev/null || true)
+    for p in $pids; do
+        echo "Stopping PID $p..."
+        kill "$p" 2>/dev/null || true
+    done
+    sleep 1
+}
+
+if [[ "${1:-}" == "--stop" ]]; then
+    stop_app
+    echo "Done."
+    exit 0
+fi
+
+stop_app
+
+echo "Building ($RID)..."
+"$DOTNET" publish "$CSPROJ" -c Debug -r "$RID" --self-contained \
+    -p:PublishSingleFile=false -o "$PUBLISH_DIR" 2>&1 | tail -3
+
+echo "Creating dev .app bundle..."
+rm -rf "$APP_BUNDLE"
+mkdir -p "$APP_BUNDLE/Contents/MacOS"
+mkdir -p "$APP_BUNDLE/Contents/Resources"
+
+# Info.plist with NSMicrophoneUsageDescription — this is the key
+cp "$PROJECT_DIR/src/$APP_NAME/Info.plist" "$APP_BUNDLE/Contents/"
+
+# Copy all published files
+cp -R "$PUBLISH_DIR/"* "$APP_BUNDLE/Contents/MacOS/"
+chmod +x "$APP_BUNDLE/Contents/MacOS/$APP_NAME"
+
+# Copy icon if present
+if [[ -f "$PROJECT_DIR/src/$APP_NAME/Assets/CopilotVoice.icns" ]]; then
+    cp "$PROJECT_DIR/src/$APP_NAME/Assets/CopilotVoice.icns" "$APP_BUNDLE/Contents/Resources/"
+fi
+
+echo "Launching $APP_BUNDLE..."
+
+# Source env vars (Azure keys etc.)
+source ~/.zprofile 2>/dev/null || true
+
+# Run in foreground so you see console output
+open -W "$APP_BUNDLE" --stdout "$(tty)" --stderr "$(tty)" 2>/dev/null \
+    || "$APP_BUNDLE/Contents/MacOS/$APP_NAME"

--- a/src/CopilotVoice/AppServices.cs
+++ b/src/CopilotVoice/AppServices.cs
@@ -133,7 +133,7 @@ public sealed class AppServices : IDisposable
         catch (Exception ex)
         {
             Log($"Bridge server failed: {ex.Message}");
-            return;
+            // Don't abort — Voice Live API can work without the bridge
         }
 
         // 2. Connect to Voice Live API (if credentials configured)
@@ -143,6 +143,8 @@ public sealed class AppServices : IDisposable
         var envEndpoint = Environment.GetEnvironmentVariable("AZURE_VOICELIVE_ENDPOINT");
         if (string.IsNullOrEmpty(endpoint) && !string.IsNullOrEmpty(envEndpoint))
             endpoint = envEndpoint;
+
+        Log($"Voice Live: endpoint={endpoint?[..Math.Min(endpoint?.Length ?? 0, 60)]}..., key={(apiKey is not null ? apiKey[..Math.Min(apiKey.Length, 8)] + "..." : "NULL")}");
 
         if (!string.IsNullOrEmpty(endpoint))
         {

--- a/src/CopilotVoice/AppServices.cs
+++ b/src/CopilotVoice/AppServices.cs
@@ -247,6 +247,8 @@ public sealed class AppServices : IDisposable
             {
                 var audioBuffer = new List<byte>();
                 var bufferLock = new object();
+                var transcriptBuilder = new System.Text.StringBuilder();
+                var transcriptLock = new object();
 
                 _bridgeServer.SpeakRequested += text =>
                 {
@@ -263,16 +265,31 @@ public sealed class AppServices : IDisposable
                     {
                         _voiceLiveSession.AudioReceived -= onAudio;
                         _voiceLiveSession.ResponseDone -= onDone;
+                        _voiceLiveSession.TranscriptReceived -= onTranscript;
 
                         byte[] toPlay;
                         lock (bufferLock) { toPlay = audioBuffer.ToArray(); audioBuffer.Clear(); }
 
                         if (toPlay.Length > 0 && _audioPlayer is not null)
                             _ = _audioPlayer.PlayAsync(toPlay);
+
+                        // Send transcript back to bridge so /speak can return it
+                        lock (transcriptLock)
+                        {
+                            _bridgeServer.NotifySpeakResponse(transcriptBuilder.ToString());
+                            transcriptBuilder.Clear();
+                        }
                     }
 
                     _voiceLiveSession.AudioReceived += onAudio;
                     _voiceLiveSession.ResponseDone += onDone;
+
+                    // Collect transcript deltas
+                    void onTranscript(string delta)
+                    {
+                        lock (transcriptLock) { transcriptBuilder.Append(delta); }
+                    }
+                    _voiceLiveSession.TranscriptReceived += onTranscript;
 
                     _ = _voiceLiveSession.SendTextAsync(text);
                     Log($"Bridge → Realtime API: \"{text[..Math.Min(text.Length, 60)]}\"");

--- a/src/CopilotVoice/AppServices.cs
+++ b/src/CopilotVoice/AppServices.cs
@@ -296,6 +296,42 @@ public sealed class AppServices : IDisposable
                 };
                 Log("Bridge /speak → Realtime API wired");
             }
+
+            // 7. Forward ALL agent transcripts to CLI sessions
+            //    This covers both push-to-talk and /speak responses
+            if (_bridgeServer is not null)
+            {
+                var fullTranscript = new System.Text.StringBuilder();
+                var tLock = new object();
+
+                _voiceLiveSession.TranscriptReceived += delta =>
+                {
+                    lock (tLock) { fullTranscript.Append(delta); }
+                };
+
+                _voiceLiveSession.ResponseDone += () =>
+                {
+                    string transcript;
+                    lock (tLock)
+                    {
+                        transcript = fullTranscript.ToString();
+                        fullTranscript.Clear();
+                    }
+
+                    if (string.IsNullOrWhiteSpace(transcript)) return;
+
+                    // Forward to all connected CLI sessions
+                    var sessions = _bridgeServer.SessionBridge.ConnectedSessions;
+                    foreach (var sid in sessions)
+                    {
+                        _bridgeServer.SessionBridge.QueueCommand(sid,
+                            new SendPromptCommand(
+                                $"[Voice Agent said to user]: {transcript}"));
+                    }
+                    Log($"Agent transcript → CLI: \"{transcript[..Math.Min(transcript.Length, 80)]}\"");
+                };
+                Log("Agent transcript → CLI forwarding wired");
+            }
         }
     }
 

--- a/src/CopilotVoice/AppServices.cs
+++ b/src/CopilotVoice/AppServices.cs
@@ -295,6 +295,9 @@ public sealed class AppServices : IDisposable
                     Log($"Bridge → Realtime API: \"{text[..Math.Min(text.Length, 60)]}\"");
                 };
                 Log("Bridge /speak → Realtime API wired");
+
+                _bridgeServer.TalkModeToggleRequested += () => ToggleTalkMode();
+                Log("Bridge /talkmode → Talk Mode wired");
             }
 
             // 7. Forward ALL agent transcripts to CLI sessions
@@ -341,6 +344,9 @@ public sealed class AppServices : IDisposable
 
     /// <summary>Whether Talk Mode is currently active.</summary>
     public bool IsTalkModeActive => _talkModeController?.IsActive ?? false;
+
+    /// <summary>Toggle Talk Mode on/off. Called from UI button or bridge endpoint.</summary>
+    public void ToggleTalkMode() => HandleDoubleTap();
 
     /// <summary>
     /// Hotkey press handler with double-tap detection.

--- a/src/CopilotVoice/AppServices.cs
+++ b/src/CopilotVoice/AppServices.cs
@@ -241,6 +241,44 @@ public sealed class AppServices : IDisposable
 
             await _pttController.StartAsync();
             Log("PushToTalkController: started");
+
+            // 6. Wire bridge /speak endpoint → Realtime API
+            if (_bridgeServer is not null)
+            {
+                var audioBuffer = new List<byte>();
+                var bufferLock = new object();
+
+                _bridgeServer.SpeakRequested += text =>
+                {
+                    if (_voiceLiveSession is null) return;
+
+                    lock (bufferLock) { audioBuffer.Clear(); }
+
+                    // Subscribe to audio for this response
+                    void onAudio(ReadOnlyMemory<byte> audio)
+                    {
+                        lock (bufferLock) { audioBuffer.AddRange(audio.ToArray()); }
+                    }
+                    void onDone()
+                    {
+                        _voiceLiveSession.AudioReceived -= onAudio;
+                        _voiceLiveSession.ResponseDone -= onDone;
+
+                        byte[] toPlay;
+                        lock (bufferLock) { toPlay = audioBuffer.ToArray(); audioBuffer.Clear(); }
+
+                        if (toPlay.Length > 0 && _audioPlayer is not null)
+                            _ = _audioPlayer.PlayAsync(toPlay);
+                    }
+
+                    _voiceLiveSession.AudioReceived += onAudio;
+                    _voiceLiveSession.ResponseDone += onDone;
+
+                    _ = _voiceLiveSession.SendTextAsync(text);
+                    Log($"Bridge → Realtime API: \"{text[..Math.Min(text.Length, 60)]}\"");
+                };
+                Log("Bridge /speak → Realtime API wired");
+            }
         }
     }
 

--- a/src/CopilotVoice/Audio/AudioPlayer.cs
+++ b/src/CopilotVoice/Audio/AudioPlayer.cs
@@ -13,8 +13,8 @@ namespace CopilotVoice.Audio;
 /// </summary>
 public sealed class AudioPlayer : IAudioPlayer
 {
-    /// <summary>Sample rate required by Azure Voice Live API.</summary>
-    private const int SampleRate = 16000;
+    /// <summary>Sample rate required by Azure Voice Live API (24 kHz for pcm16).</summary>
+    private const int SampleRate = 24000;
 
     /// <summary>Mono channel.</summary>
     private const int ChannelCount = 1;
@@ -22,7 +22,7 @@ public sealed class AudioPlayer : IAudioPlayer
     /// <summary>
     /// Frames per callback buffer: 1600 samples = 100 ms at 16 kHz.
     /// </summary>
-    private const uint FramesPerBuffer = 1600;
+    private const uint FramesPerBuffer = 2400;
 
     /// <summary>Bytes per PCM16 sample.</summary>
     private const int BytesPerSample = 2;

--- a/src/CopilotVoice/Audio/MicCapture.cs
+++ b/src/CopilotVoice/Audio/MicCapture.cs
@@ -3,25 +3,31 @@ using System.Diagnostics;
 namespace CopilotVoice.Audio;
 
 /// <summary>
-/// Captures microphone audio in PCM16 format using sox/rec (macOS/Linux)
-/// or ffmpeg as fallback. Outputs 24kHz mono PCM16 for the Voice Live API.
+/// Captures microphone audio in PCM16 format using an external process.
+/// Prefers ffmpeg with AVFoundation (macOS) which correctly accesses USB mics
+/// like the C920. Falls back to sox/rec if ffmpeg is unavailable.
 ///
-/// Why not PortAudio? On macOS, Avalonia creates a GUI window which makes
-/// the dotnet process subject to GUI app microphone permission rules.
-/// Without NSMicrophoneUsageDescription in a signed .app bundle's Info.plist,
-/// CoreAudio silently returns all-zero buffers. Spawning rec/ffmpeg as a
-/// child process bypasses this because CLI tools inherit the terminal's
-/// microphone permission. When published as a proper .app bundle with
-/// Info.plist, PortAudio can be used directly.
+/// Background: PortAudio and sox/rec use CoreAudio HAL which returns silent
+/// zero-buffers from some USB devices on macOS. QuickTime and ffmpeg use
+/// AVFoundation which works correctly. The original project used Azure Speech
+/// SDK's AudioConfig.FromDefaultMicrophoneInput() which also uses AVFoundation.
+///
+/// macOS TCC (Transparency, Consent, and Control) note:
+/// Microphone access requires the responsible app (terminal or .app bundle) to
+/// have NSMicrophoneUsageDescription in its Info.plist. If denied, CoreAudio HAL
+/// silently returns zeros while AVFoundation (ffmpeg) crashes with SIGABRT (134).
+/// When running as a .app bundle, the app's own Info.plist grants this.
+/// When running from a terminal, the terminal app must have mic permission.
 /// </summary>
 public sealed class MicCapture : IMicCapture
 {
-    /// <summary>API expects 24kHz PCM16 mono.</summary>
     private const int SampleRate = 24000;
     private const int Channels = 1;
     private const int BytesPerSample = 2;
-    /// <summary>Read ~100ms chunks from the process.</summary>
-    private const int ChunkBytes = SampleRate * BytesPerSample * Channels / 10; // 4800 bytes
+    private const int ChunkBytes = SampleRate * BytesPerSample * Channels / 10; // 4800 bytes = 100ms
+
+    /// <summary>Exit code 134 = SIGABRT (128 + 6), the macOS TCC denial signal.</summary>
+    private const int SigAbrtExitCode = 134;
 
     private readonly object _lock = new();
     private Process? _process;
@@ -42,51 +48,167 @@ public sealed class MicCapture : IMicCapture
         {
             if (_isCapturing) return Task.CompletedTask;
 
-            // Use sox/rec to capture raw PCM16 audio from default mic
-            var psi = new ProcessStartInfo
+            _process = StartCaptureProcess();
+            _isCapturing = true;
+            _readCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            _readTask = Task.Run(() => ReadAudioLoop(_process, _readCts.Token));
+
+            Console.Error.WriteLine(
+                $"[MicCapture] Started — pid={_process.Id}, rate={SampleRate}Hz, format=PCM16 mono");
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static Process StartCaptureProcess()
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            var p = TryStartFfmpegAvFoundation();
+            if (p is not null) return p;
+        }
+
+        // Cross-platform: ffmpeg with default input (ALSA on Linux, dshow on Windows)
+        {
+            var p = TryStartFfmpegDefault();
+            if (p is not null) return p;
+        }
+
+        // Fallback: sox/rec (uses CoreAudio HAL on macOS — may return silence from USB mics)
+        {
+            var p = TryStartSoxRec();
+            if (p is not null) return p;
+        }
+
+        throw new InvalidOperationException(
+            "No audio capture tool found. Install ffmpeg (brew install ffmpeg) or sox (brew install sox).");
+    }
+
+    /// <summary>
+    /// ffmpeg with AVFoundation — the preferred path on macOS.
+    /// AVFoundation correctly handles USB mic sample rate conversion and
+    /// triggers the macOS TCC permission prompt (unlike CoreAudio HAL).
+    /// If the app/terminal lacks NSMicrophoneUsageDescription, ffmpeg will
+    /// be killed with SIGABRT (exit 134). We detect this and log guidance.
+    /// </summary>
+    private static Process? TryStartFfmpegAvFoundation()
+    {
+        try
+        {
+            var p = Process.Start(new ProcessStartInfo
+            {
+                FileName = "ffmpeg",
+                Arguments = "-f avfoundation -i :default -ar 24000 -ac 1 -f s16le -loglevel quiet pipe:1",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            });
+            if (p is null) return null;
+
+            // Give ffmpeg a moment to initialize AVFoundation and trigger TCC check.
+            // SIGABRT from TCC denial happens during device open, within ~200ms.
+            if (p.WaitForExit(500))
+            {
+                if (p.ExitCode == SigAbrtExitCode)
+                {
+                    Console.Error.WriteLine(
+                        "[MicCapture] ffmpeg killed by macOS TCC — microphone permission denied.\n" +
+                        "  Fix: grant mic access to your terminal app in System Settings → Privacy & Security → Microphone.\n" +
+                        "  Or run as a .app bundle (scripts/bundle-macos.sh) which has NSMicrophoneUsageDescription.");
+                    p.Dispose();
+                    return null;
+                }
+
+                Console.Error.WriteLine($"[MicCapture] ffmpeg exited early (code={p.ExitCode})");
+                p.Dispose();
+                return null;
+            }
+
+            Console.Error.WriteLine("[MicCapture] Using ffmpeg (AVFoundation)");
+            return p;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// ffmpeg with platform default input (ALSA on Linux, dshow on Windows).
+    /// Not used on macOS since AVFoundation is preferred there.
+    /// </summary>
+    private static Process? TryStartFfmpegDefault()
+    {
+        if (OperatingSystem.IsMacOS()) return null;
+
+        string inputFormat;
+        string inputDevice;
+        if (OperatingSystem.IsLinux())
+        {
+            inputFormat = "alsa";
+            inputDevice = "default";
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            inputFormat = "dshow";
+            inputDevice = "audio=default";
+        }
+        else
+        {
+            return null;
+        }
+
+        try
+        {
+            var p = Process.Start(new ProcessStartInfo
+            {
+                FileName = "ffmpeg",
+                Arguments = $"-f {inputFormat} -i {inputDevice} -ar 24000 -ac 1 -f s16le -loglevel quiet pipe:1",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
+            });
+            if (p is not null)
+            {
+                Console.Error.WriteLine($"[MicCapture] Using ffmpeg ({inputFormat})");
+                return p;
+            }
+        }
+        catch { }
+
+        return null;
+    }
+
+    /// <summary>
+    /// sox/rec fallback. Uses CoreAudio HAL on macOS which may return silence
+    /// from USB microphones due to sample rate negotiation failures.
+    /// Works reliably on Linux (ALSA) and Windows (waveIn).
+    /// </summary>
+    private static Process? TryStartSoxRec()
+    {
+        try
+        {
+            var p = Process.Start(new ProcessStartInfo
             {
                 FileName = "rec",
-                // Output raw PCM16, 24kHz, mono, 16-bit to stdout
                 Arguments = "-q -r 24000 -c 1 -b 16 -e signed-integer -t raw -",
                 UseShellExecute = false,
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 CreateNoWindow = true,
-            };
-
-            try
+            });
+            if (p is not null)
             {
-                _process = Process.Start(psi);
+                Console.Error.WriteLine(
+                    "[MicCapture] Using sox/rec (CoreAudio HAL — USB mics may produce silence on macOS)");
+                return p;
             }
-            catch (Exception)
-            {
-                // Try ffmpeg as fallback
-                psi.FileName = "ffmpeg";
-                psi.Arguments = "-f avfoundation -i :default -ar 24000 -ac 1 -f s16le -loglevel quiet -";
-                try
-                {
-                    _process = Process.Start(psi);
-                }
-                catch (Exception ex)
-                {
-                    throw new InvalidOperationException(
-                        "No audio capture tool found. Install sox (brew install sox) or ffmpeg.", ex);
-                }
-            }
-
-            if (_process is null)
-                throw new InvalidOperationException("Failed to start audio capture process.");
-
-            _isCapturing = true;
-            _readCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-
-            // Read audio data from stdout in a background task
-            _readTask = Task.Run(() => ReadAudioLoop(_process, _readCts.Token));
-
-            Console.Error.WriteLine($"[MicCapture] Started — pid={_process.Id}, rate={SampleRate}Hz, format=PCM16 mono");
         }
+        catch { }
 
-        return Task.CompletedTask;
+        return null;
     }
 
     public Task StopAsync()
@@ -118,23 +240,27 @@ public sealed class MicCapture : IMicCapture
                 {
                     int read = await stream.ReadAsync(
                         buffer.AsMemory(totalRead, ChunkBytes - totalRead), ct);
-                    if (read == 0) break; // process ended
+                    if (read == 0) break;
                     totalRead += read;
                 }
 
                 if (totalRead > 0 && _isCapturing)
-                {
-                    var chunk = buffer.AsMemory(0, totalRead);
-                    AudioCaptured?.Invoke(chunk);
-                }
+                    AudioCaptured?.Invoke(buffer.AsMemory(0, totalRead));
 
                 if (totalRead == 0) break;
             }
         }
-        catch (OperationCanceledException) { /* expected */ }
+        catch (OperationCanceledException) { }
         catch (Exception ex)
         {
             Console.Error.WriteLine($"[MicCapture] Read error: {ex.Message}");
+        }
+
+        // Check if process died from TCC denial during capture
+        if (OperatingSystem.IsMacOS() && proc.HasExited && proc.ExitCode == SigAbrtExitCode)
+        {
+            Console.Error.WriteLine(
+                "[MicCapture] Capture process killed by macOS (SIGABRT) — likely TCC mic permission denied.");
         }
     }
 
@@ -143,7 +269,7 @@ public sealed class MicCapture : IMicCapture
         _readCts?.Cancel();
         if (_process is not null && !_process.HasExited)
         {
-            try { _process.Kill(); } catch { /* best effort */ }
+            try { _process.Kill(); } catch { }
             try { _process.WaitForExit(2000); } catch { }
         }
         try { _process?.Dispose(); } catch { }

--- a/src/CopilotVoice/Audio/MicCapture.cs
+++ b/src/CopilotVoice/Audio/MicCapture.cs
@@ -11,17 +11,17 @@ namespace CopilotVoice.Audio;
 /// </summary>
 public sealed class MicCapture : IMicCapture
 {
-    /// <summary>Sample rate required by Azure Voice Live API.</summary>
-    private const int SampleRate = 16000;
+    /// <summary>Sample rate required by Azure Voice Live API (24 kHz for pcm16).</summary>
+    private const int SampleRate = 24000;
 
     /// <summary>Mono channel.</summary>
     private const int ChannelCount = 1;
 
     /// <summary>
-    /// Frames per callback buffer: 1600 samples = 100 ms at 16 kHz.
+    /// Frames per callback buffer: 2400 samples = 100 ms at 24 kHz.
     /// Balances low latency with reasonable callback overhead.
     /// </summary>
-    private const uint FramesPerBuffer = 1600;
+    private const uint FramesPerBuffer = 2400;
 
     /// <summary>Bytes per PCM16 sample.</summary>
     private const int BytesPerSample = 2;
@@ -115,6 +115,8 @@ public sealed class MicCapture : IMicCapture
     /// PortAudio input callback — fires from the audio thread.
     /// Copies PCM16 data into a managed byte array and raises <see cref="AudioCaptured"/>.
     /// </summary>
+    private int _callbackCount;
+
     private StreamCallbackResult OnInputCallback(
         IntPtr input,
         IntPtr output,
@@ -129,6 +131,10 @@ public sealed class MicCapture : IMicCapture
         int byteCount = (int)(frameCount * ChannelCount * BytesPerSample);
         var buffer = new byte[byteCount];
         Marshal.Copy(input, buffer, 0, byteCount);
+
+        _callbackCount++;
+        if (_callbackCount <= 3)
+            Console.Error.WriteLine($"[MicCapture] Callback #{_callbackCount}: {byteCount} bytes, frameCount={frameCount}");
 
         // Fire event — subscribers should not block the audio thread.
         AudioCaptured?.Invoke(buffer);

--- a/src/CopilotVoice/Audio/MicCapture.cs
+++ b/src/CopilotVoice/Audio/MicCapture.cs
@@ -5,6 +5,14 @@ namespace CopilotVoice.Audio;
 /// <summary>
 /// Captures microphone audio in PCM16 format using sox/rec (macOS/Linux)
 /// or ffmpeg as fallback. Outputs 24kHz mono PCM16 for the Voice Live API.
+///
+/// Why not PortAudio? On macOS, Avalonia creates a GUI window which makes
+/// the dotnet process subject to GUI app microphone permission rules.
+/// Without NSMicrophoneUsageDescription in a signed .app bundle's Info.plist,
+/// CoreAudio silently returns all-zero buffers. Spawning rec/ffmpeg as a
+/// child process bypasses this because CLI tools inherit the terminal's
+/// microphone permission. When published as a proper .app bundle with
+/// Info.plist, PortAudio can be used directly.
 /// </summary>
 public sealed class MicCapture : IMicCapture
 {

--- a/src/CopilotVoice/Audio/MicCapture.cs
+++ b/src/CopilotVoice/Audio/MicCapture.cs
@@ -1,102 +1,86 @@
-using System.Runtime.InteropServices;
-using PortAudioSharp;
+using System.Diagnostics;
 
 namespace CopilotVoice.Audio;
 
 /// <summary>
-/// Captures microphone audio in PCM16 format (16 kHz, mono) using PortAudio.
-/// Start/Stop are idempotent — calling Start while already capturing is a no-op.
-/// Thread-safe: the PortAudio callback fires from an audio thread; captured
-/// data is copied and delivered via the <see cref="AudioCaptured"/> event.
+/// Captures microphone audio in PCM16 format using sox/rec (macOS/Linux)
+/// or ffmpeg as fallback. Outputs 24kHz mono PCM16 for the Voice Live API.
 /// </summary>
 public sealed class MicCapture : IMicCapture
 {
-    /// <summary>Capture at 48kHz (widely supported), resample to 24kHz for API.</summary>
-    private const int CaptureSampleRate = 48000;
-
-    /// <summary>API expects 24kHz PCM16.</summary>
-    private const int ApiSampleRate = 24000;
-
-    /// <summary>Mono channel.</summary>
-    private const int ChannelCount = 1;
-
-    /// <summary>
-    /// Frames per callback buffer: 4800 samples = 100 ms at 48 kHz.
-    /// Balances low latency with reasonable callback overhead.
-    /// </summary>
-    private const uint FramesPerBuffer = 4800;
-
-    /// <summary>Bytes per PCM16 sample.</summary>
+    /// <summary>API expects 24kHz PCM16 mono.</summary>
+    private const int SampleRate = 24000;
+    private const int Channels = 1;
     private const int BytesPerSample = 2;
+    /// <summary>Read ~100ms chunks from the process.</summary>
+    private const int ChunkBytes = SampleRate * BytesPerSample * Channels / 10; // 4800 bytes
 
     private readonly object _lock = new();
-    private PortAudioSharp.Stream? _stream;
-    private bool _disposed;
+    private Process? _process;
     private volatile bool _isCapturing;
-    private bool _paInitialized;
+    private bool _disposed;
+    private CancellationTokenSource? _readCts;
+    private Task? _readTask;
 
     public bool IsCapturing => _isCapturing;
-
     public event Action<ReadOnlyMemory<byte>>? AudioCaptured;
 
-    /// <summary>Begin capturing audio from the default microphone.</summary>
-    /// <exception cref="InvalidOperationException">No microphone is available.</exception>
     public Task StartAsync(CancellationToken ct = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
         if (_isCapturing) return Task.CompletedTask;
 
         lock (_lock)
         {
             if (_isCapturing) return Task.CompletedTask;
 
-            PortAudioLifecycle.EnsureInitialized();
-            _paInitialized = true;
-
-            var inputDevice = PortAudioSharp.PortAudio.DefaultInputDevice;
-            if (inputDevice == PortAudioSharp.PortAudio.NoDevice)
+            // Use sox/rec to capture raw PCM16 audio from default mic
+            var psi = new ProcessStartInfo
             {
-                PortAudioLifecycle.Release();
-                _paInitialized = false;
-                throw new InvalidOperationException(
-                    "No microphone available. Check system audio settings.");
-            }
-
-            var deviceInfo = PortAudioSharp.PortAudio.GetDeviceInfo(inputDevice);
-            var inputParams = new StreamParameters
-            {
-                device = inputDevice,
-                channelCount = ChannelCount,
-                sampleFormat = SampleFormat.Int16,
-                suggestedLatency = deviceInfo.defaultLowInputLatency,
-                hostApiSpecificStreamInfo = IntPtr.Zero,
+                FileName = "rec",
+                // Output raw PCM16, 24kHz, mono, 16-bit to stdout
+                Arguments = "-q -r 24000 -c 1 -b 16 -e signed-integer -t raw -",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true,
             };
 
-            _stream = new PortAudioSharp.Stream(
-                inParams: inputParams,
-                outParams: null,
-                sampleRate: CaptureSampleRate,
-                framesPerBuffer: FramesPerBuffer,
-                streamFlags: StreamFlags.ClipOff,
-                callback: OnInputCallback,
-                userData: null!);
+            try
+            {
+                _process = Process.Start(psi);
+            }
+            catch (Exception)
+            {
+                // Try ffmpeg as fallback
+                psi.FileName = "ffmpeg";
+                psi.Arguments = "-f avfoundation -i :default -ar 24000 -ac 1 -f s16le -loglevel quiet -";
+                try
+                {
+                    _process = Process.Start(psi);
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException(
+                        "No audio capture tool found. Install sox (brew install sox) or ffmpeg.", ex);
+                }
+            }
 
-            _stream.Start();
+            if (_process is null)
+                throw new InvalidOperationException("Failed to start audio capture process.");
+
             _isCapturing = true;
+            _readCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-            // Register cancellation to stop capture
-            if (ct.CanBeCanceled)
-                ct.Register(() => _ = StopAsync());
+            // Read audio data from stdout in a background task
+            _readTask = Task.Run(() => ReadAudioLoop(_process, _readCts.Token));
 
-            Console.Error.WriteLine(
-                $"[MicCapture] Started — device: {deviceInfo.name}, capture: {CaptureSampleRate} Hz, API: {ApiSampleRate} Hz");
+            Console.Error.WriteLine($"[MicCapture] Started — pid={_process.Id}, rate={SampleRate}Hz, format=PCM16 mono");
         }
 
         return Task.CompletedTask;
     }
 
-    /// <summary>Stop capturing audio. Idempotent — safe to call when not capturing.</summary>
     public Task StopAsync()
     {
         if (!_isCapturing) return Task.CompletedTask;
@@ -104,77 +88,60 @@ public sealed class MicCapture : IMicCapture
         lock (_lock)
         {
             if (!_isCapturing) return Task.CompletedTask;
-
             _isCapturing = false;
-            CleanupStream();
-
+            KillProcess();
             Console.Error.WriteLine("[MicCapture] Stopped");
         }
 
         return Task.CompletedTask;
     }
 
-    /// <summary>
-    /// PortAudio input callback — fires from the audio thread.
-    /// Copies PCM16 data into a managed byte array and raises <see cref="AudioCaptured"/>.
-    /// </summary>
-    private int _callbackCount;
-
-    private StreamCallbackResult OnInputCallback(
-        IntPtr input,
-        IntPtr output,
-        uint frameCount,
-        ref StreamCallbackTimeInfo timeInfo,
-        StreamCallbackFlags statusFlags,
-        IntPtr userData)
+    private async Task ReadAudioLoop(Process proc, CancellationToken ct)
     {
-        if (!_isCapturing || input == IntPtr.Zero)
-            return StreamCallbackResult.Continue;
+        var buffer = new byte[ChunkBytes];
+        var stream = proc.StandardOutput.BaseStream;
 
-        int capturedBytes = (int)(frameCount * ChannelCount * BytesPerSample);
-        var capturedBuffer = new byte[capturedBytes];
-        Marshal.Copy(input, capturedBuffer, 0, capturedBytes);
-
-        // Downsample from 48kHz to 24kHz: take every other sample (2:1 ratio)
-        int resampledSamples = (int)frameCount / 2;
-        var resampledBuffer = new byte[resampledSamples * BytesPerSample];
-        for (int i = 0; i < resampledSamples; i++)
+        try
         {
-            int srcOffset = i * 2 * BytesPerSample; // skip every other sample
-            int dstOffset = i * BytesPerSample;
-            resampledBuffer[dstOffset] = capturedBuffer[srcOffset];
-            resampledBuffer[dstOffset + 1] = capturedBuffer[srcOffset + 1];
-        }
+            while (!ct.IsCancellationRequested && _isCapturing)
+            {
+                int totalRead = 0;
+                while (totalRead < ChunkBytes)
+                {
+                    int read = await stream.ReadAsync(
+                        buffer.AsMemory(totalRead, ChunkBytes - totalRead), ct);
+                    if (read == 0) break; // process ended
+                    totalRead += read;
+                }
 
-        _callbackCount++;
-        if (_callbackCount <= 3)
+                if (totalRead > 0 && _isCapturing)
+                {
+                    var chunk = buffer.AsMemory(0, totalRead);
+                    AudioCaptured?.Invoke(chunk);
+                }
+
+                if (totalRead == 0) break;
+            }
+        }
+        catch (OperationCanceledException) { /* expected */ }
+        catch (Exception ex)
         {
-            int nonZero = 0;
-            for (int i = 0; i < Math.Min(resampledBuffer.Length, 100); i++)
-                if (resampledBuffer[i] != 0) nonZero++;
-            Console.Error.WriteLine($"[MicCapture] Callback #{_callbackCount}: {resampledBuffer.Length} bytes (resampled from {capturedBytes}), nonZero={nonZero}/100");
+            Console.Error.WriteLine($"[MicCapture] Read error: {ex.Message}");
         }
-
-        AudioCaptured?.Invoke(resampledBuffer);
-
-        return StreamCallbackResult.Continue;
     }
 
-    /// <summary>Releases the PortAudio stream and PA reference.</summary>
-    private void CleanupStream()
+    private void KillProcess()
     {
-        if (_stream is not null)
+        _readCts?.Cancel();
+        if (_process is not null && !_process.HasExited)
         {
-            try { _stream.Abort(); } catch { /* stream may already be stopped */ }
-            try { _stream.Dispose(); } catch { /* best effort */ }
-            _stream = null;
+            try { _process.Kill(); } catch { /* best effort */ }
+            try { _process.WaitForExit(2000); } catch { }
         }
-
-        if (_paInitialized)
-        {
-            PortAudioLifecycle.Release();
-            _paInitialized = false;
-        }
+        try { _process?.Dispose(); } catch { }
+        _process = null;
+        _readCts?.Dispose();
+        _readCts = null;
     }
 
     public void Dispose()
@@ -184,7 +151,7 @@ public sealed class MicCapture : IMicCapture
             if (_disposed) return;
             _disposed = true;
             _isCapturing = false;
-            CleanupStream();
+            KillProcess();
         }
     }
 }

--- a/src/CopilotVoice/Audio/MicCapture.cs
+++ b/src/CopilotVoice/Audio/MicCapture.cs
@@ -11,17 +11,20 @@ namespace CopilotVoice.Audio;
 /// </summary>
 public sealed class MicCapture : IMicCapture
 {
-    /// <summary>Sample rate required by Azure Voice Live API (24 kHz for pcm16).</summary>
-    private const int SampleRate = 24000;
+    /// <summary>Capture at 48kHz (widely supported), resample to 24kHz for API.</summary>
+    private const int CaptureSampleRate = 48000;
+
+    /// <summary>API expects 24kHz PCM16.</summary>
+    private const int ApiSampleRate = 24000;
 
     /// <summary>Mono channel.</summary>
     private const int ChannelCount = 1;
 
     /// <summary>
-    /// Frames per callback buffer: 2400 samples = 100 ms at 24 kHz.
+    /// Frames per callback buffer: 4800 samples = 100 ms at 48 kHz.
     /// Balances low latency with reasonable callback overhead.
     /// </summary>
-    private const uint FramesPerBuffer = 2400;
+    private const uint FramesPerBuffer = 4800;
 
     /// <summary>Bytes per PCM16 sample.</summary>
     private const int BytesPerSample = 2;
@@ -73,7 +76,7 @@ public sealed class MicCapture : IMicCapture
             _stream = new PortAudioSharp.Stream(
                 inParams: inputParams,
                 outParams: null,
-                sampleRate: SampleRate,
+                sampleRate: CaptureSampleRate,
                 framesPerBuffer: FramesPerBuffer,
                 streamFlags: StreamFlags.ClipOff,
                 callback: OnInputCallback,
@@ -87,7 +90,7 @@ public sealed class MicCapture : IMicCapture
                 ct.Register(() => _ = StopAsync());
 
             Console.Error.WriteLine(
-                $"[MicCapture] Started — device: {deviceInfo.name}, rate: {SampleRate} Hz");
+                $"[MicCapture] Started — device: {deviceInfo.name}, capture: {CaptureSampleRate} Hz, API: {ApiSampleRate} Hz");
         }
 
         return Task.CompletedTask;
@@ -128,16 +131,31 @@ public sealed class MicCapture : IMicCapture
         if (!_isCapturing || input == IntPtr.Zero)
             return StreamCallbackResult.Continue;
 
-        int byteCount = (int)(frameCount * ChannelCount * BytesPerSample);
-        var buffer = new byte[byteCount];
-        Marshal.Copy(input, buffer, 0, byteCount);
+        int capturedBytes = (int)(frameCount * ChannelCount * BytesPerSample);
+        var capturedBuffer = new byte[capturedBytes];
+        Marshal.Copy(input, capturedBuffer, 0, capturedBytes);
+
+        // Downsample from 48kHz to 24kHz: take every other sample (2:1 ratio)
+        int resampledSamples = (int)frameCount / 2;
+        var resampledBuffer = new byte[resampledSamples * BytesPerSample];
+        for (int i = 0; i < resampledSamples; i++)
+        {
+            int srcOffset = i * 2 * BytesPerSample; // skip every other sample
+            int dstOffset = i * BytesPerSample;
+            resampledBuffer[dstOffset] = capturedBuffer[srcOffset];
+            resampledBuffer[dstOffset + 1] = capturedBuffer[srcOffset + 1];
+        }
 
         _callbackCount++;
         if (_callbackCount <= 3)
-            Console.Error.WriteLine($"[MicCapture] Callback #{_callbackCount}: {byteCount} bytes, frameCount={frameCount}");
+        {
+            int nonZero = 0;
+            for (int i = 0; i < Math.Min(resampledBuffer.Length, 100); i++)
+                if (resampledBuffer[i] != 0) nonZero++;
+            Console.Error.WriteLine($"[MicCapture] Callback #{_callbackCount}: {resampledBuffer.Length} bytes (resampled from {capturedBytes}), nonZero={nonZero}/100");
+        }
 
-        // Fire event — subscribers should not block the audio thread.
-        AudioCaptured?.Invoke(buffer);
+        AudioCaptured?.Invoke(resampledBuffer);
 
         return StreamCallbackResult.Continue;
     }

--- a/src/CopilotVoice/Bridge/BridgeServer.cs
+++ b/src/CopilotVoice/Bridge/BridgeServer.cs
@@ -37,6 +37,15 @@ public sealed class BridgeServer : IAsyncDisposable
     /// <summary>Fired when a speak request is received (text to be spoken).</summary>
     public event Action<string>? SpeakRequested;
 
+    /// <summary>Last transcript received from the Realtime API in response to a /speak request.</summary>
+    public string? LastSpeakTranscript { get; private set; }
+
+    /// <summary>Fired when the Realtime API finishes responding to a /speak request.</summary>
+    public event Action<string>? SpeakResponseReady;
+
+    /// <summary>Raise the SpeakResponseReady event from outside the class.</summary>
+    public void NotifySpeakResponse(string transcript) => SpeakResponseReady?.Invoke(transcript);
+
     /// <summary>Fired when an avatar expression change is requested.</summary>
     public event Action<string>? AvatarRequested;
 
@@ -286,10 +295,25 @@ public sealed class BridgeServer : IAsyncDisposable
                 return Results.BadRequest(new { error = "missing required field: text" });
             }
 
-            SpeakRequested?.Invoke(textProp.GetString()!);
-        }
+            // Wait for the Realtime API to finish responding (up to 30s)
+            var tcs = new TaskCompletionSource<string>();
+            void onResponse(string transcript) => tcs.TrySetResult(transcript);
+            SpeakResponseReady += onResponse;
 
-        return Results.Ok(new { status = "ok" });
+            SpeakRequested?.Invoke(textProp.GetString()!);
+
+            var timeout = Task.Delay(TimeSpan.FromSeconds(30));
+            var completed = await Task.WhenAny(tcs.Task, timeout);
+
+            SpeakResponseReady -= onResponse;
+
+            if (completed == tcs.Task)
+            {
+                return Results.Ok(new { status = "ok", transcript = tcs.Task.Result });
+            }
+
+            return Results.Ok(new { status = "ok", transcript = "(no response within 30s)" });
+        }
     }
 
     private async Task<IResult> HandleAvatar(HttpContext context)

--- a/src/CopilotVoice/Bridge/BridgeServer.cs
+++ b/src/CopilotVoice/Bridge/BridgeServer.cs
@@ -46,6 +46,9 @@ public sealed class BridgeServer : IAsyncDisposable
     /// <summary>Raise the SpeakResponseReady event from outside the class.</summary>
     public void NotifySpeakResponse(string transcript) => SpeakResponseReady?.Invoke(transcript);
 
+    /// <summary>Fired when a Talk Mode toggle is requested.</summary>
+    public event Action? TalkModeToggleRequested;
+
     /// <summary>Fired when an avatar expression change is requested.</summary>
     public event Action<string>? AvatarRequested;
 
@@ -91,6 +94,7 @@ public sealed class BridgeServer : IAsyncDisposable
         app.MapPost("/cli/send", (Delegate)HandleCliSend);
         app.MapPost("/speak", (Delegate)HandleSpeak);
         app.MapPost("/avatar", (Delegate)HandleAvatar);
+        app.MapPost("/talkmode", (Delegate)HandleTalkMode);
     }
 
     private IResult HandleHealth()
@@ -344,6 +348,12 @@ public sealed class BridgeServer : IAsyncDisposable
             AvatarRequested?.Invoke(exprProp.GetString()!);
         }
 
+        return Results.Ok(new { status = "ok" });
+    }
+
+    private IResult HandleTalkMode()
+    {
+        TalkModeToggleRequested?.Invoke();
         return Results.Ok(new { status = "ok" });
     }
 

--- a/src/CopilotVoice/Config/AppConfig.cs
+++ b/src/CopilotVoice/Config/AppConfig.cs
@@ -7,7 +7,6 @@ public class AppConfig
     // Authentication
     [JsonConverter(typeof(JsonStringEnumConverter))]
     public AuthMode AuthMode { get; set; } = AuthMode.SignIn;
-    [System.Text.Json.Serialization.JsonIgnore]
     public string? AzureSpeechKey { get; set; }
     public string AzureSpeechRegion { get; set; } = "centralus";
     public string? AzureResourceName { get; set; }
@@ -53,7 +52,6 @@ public class AppConfig
 
     // Voice Live API
     public string? VoiceLiveEndpoint { get; set; }
-    [System.Text.Json.Serialization.JsonIgnore]
     public string? VoiceLiveKey { get; set; }
     public string VoiceLiveModel { get; set; } = "gpt-realtime";
     public string VoiceLiveVoice { get; set; } = "alloy";

--- a/src/CopilotVoice/Config/AppConfig.cs
+++ b/src/CopilotVoice/Config/AppConfig.cs
@@ -55,7 +55,7 @@ public class AppConfig
     public string? VoiceLiveEndpoint { get; set; }
     [System.Text.Json.Serialization.JsonIgnore]
     public string? VoiceLiveKey { get; set; }
-    public string VoiceLiveModel { get; set; } = "gpt-4o-realtime-preview";
+    public string VoiceLiveModel { get; set; } = "gpt-realtime";
     public string VoiceLiveVoice { get; set; } = "alloy";
 
     // Avatar

--- a/src/CopilotVoice/Views/AvatarWindow.axaml
+++ b/src/CopilotVoice/Views/AvatarWindow.axaml
@@ -90,7 +90,7 @@
             <!-- Status Bar -->
             <Border Grid.Row="5" Padding="10,6" Background="#2D2D44"
                     CornerRadius="0,0,12,12">
-                <Grid ColumnDefinitions="Auto,*,Auto">
+                <Grid ColumnDefinitions="Auto,Auto,*,Auto">
                     <!-- Record button (red circle) -->
                     <Border x:Name="RecordButton" Grid.Column="0"
                             Width="28" Height="28" CornerRadius="14"
@@ -101,9 +101,18 @@
                                  Fill="#F38BA8" HorizontalAlignment="Center"
                                  VerticalAlignment="Center" Opacity="0.6"/>
                     </Border>
-                    <TextBlock x:Name="HotkeyLabel" Grid.Column="1" Text="⌨️ Ctrl+Space"
+                    <!-- Talk Mode toggle button -->
+                    <Border x:Name="TalkModeButton" Grid.Column="1"
+                            Width="28" Height="28" CornerRadius="14"
+                            Background="#3B3B5C" Margin="0,0,8,0"
+                            VerticalAlignment="Center" Cursor="Hand"
+                            ToolTip.Tip="Toggle Talk Mode">
+                        <TextBlock x:Name="TalkModeIcon" Text="🎙️" FontSize="14"
+                                   HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    </Border>
+                    <TextBlock x:Name="HotkeyLabel" Grid.Column="2" Text="⌨️ Ctrl+Space"
                                FontSize="10" Foreground="#6C7086" VerticalAlignment="Center"/>
-                    <TextBlock x:Name="TimerLabel" Grid.Column="2" Text=""
+                    <TextBlock x:Name="TimerLabel" Grid.Column="3" Text=""
                                FontSize="10" Foreground="#F9E2AF" VerticalAlignment="Center"/>
                 </Grid>
             </Border>

--- a/src/CopilotVoice/Views/AvatarWindow.axaml.cs
+++ b/src/CopilotVoice/Views/AvatarWindow.axaml.cs
@@ -89,6 +89,13 @@ public partial class AvatarWindow : Window
             StopRecordBlink();
             e.Handled = true;
         }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
+
+        // Talk Mode toggle button
+        TalkModeButton.AddHandler(Avalonia.Input.InputElement.PointerPressedEvent, (_, e) =>
+        {
+            _services?.ToggleTalkMode();
+            e.Handled = true;
+        }, Avalonia.Interactivity.RoutingStrategies.Tunnel);
     }
 
     public void SetServices(AppServices services)
@@ -296,6 +303,13 @@ public partial class AvatarWindow : Window
             StartRecordBlink();
         else if (state != "Recording" && _isRecordBlinking)
             StopRecordBlink();
+
+        // Update Talk Mode button appearance
+        bool talkModeActive = state.StartsWith("TalkMode:");
+        TalkModeButton.Background = new Avalonia.Media.SolidColorBrush(
+            Avalonia.Media.Color.Parse(talkModeActive ? "#2D5A27" : "#3B3B5C"));
+        TalkModeIcon.Text = talkModeActive ? "🔴" : "🎙️";
+        ToolTip.SetTip(TalkModeButton, talkModeActive ? "Stop Talk Mode" : "Start Talk Mode");
     }
 
     private void StartRecordBlink()

--- a/src/CopilotVoice/Voice/PushToTalkController.cs
+++ b/src/CopilotVoice/Voice/PushToTalkController.cs
@@ -259,18 +259,24 @@ public sealed class PushToTalkController : IPushToTalkController, IDisposable
         if (State != PushToTalkState.Recording)
             return;
 
+        Console.Error.WriteLine($"[PushToTalk] Audio chunk: {audio.Length} bytes");
         _ = SendAudioSafeAsync(audio);
     }
+
+    private int _sendCount;
 
     private async Task SendAudioSafeAsync(ReadOnlyMemory<byte> audio)
     {
         try
         {
             await _voiceSession.SendAudioAsync(audio).ConfigureAwait(false);
+            var count = Interlocked.Increment(ref _sendCount);
+            if (count <= 3)
+                Console.Error.WriteLine($"[PushToTalk] SendAudio OK #{count}: {audio.Length} bytes");
         }
         catch (Exception ex)
         {
-            Log($"SendAudio failed: {ex.Message}");
+            Log($"SendAudio FAILED: {ex.GetType().Name}: {ex.Message}");
         }
     }
 

--- a/src/CopilotVoice/Voice/TalkModeController.cs
+++ b/src/CopilotVoice/Voice/TalkModeController.cs
@@ -58,6 +58,7 @@ public sealed class TalkModeController : ITalkModeController, IDisposable
     private TalkModeState _state = TalkModeState.Off;
     private CancellationTokenSource? _sessionCts;
     private bool _disposed;
+    private volatile bool _activating;
 
     /// <summary>Maximum audio buffer size (10 MB) to prevent unbounded memory growth.</summary>
     private const int MaxAudioBufferBytes = 10 * 1024 * 1024;
@@ -67,7 +68,7 @@ public sealed class TalkModeController : ITalkModeController, IDisposable
         get { lock (_stateLock) return _state; }
     }
 
-    public bool IsActive => State != TalkModeState.Off;
+    public bool IsActive => _activating || State != TalkModeState.Off;
 
     public event Action<TalkModeState>? StateChanged;
 
@@ -90,8 +91,9 @@ public sealed class TalkModeController : ITalkModeController, IDisposable
     {
         lock (_stateLock)
         {
-            if (_state != TalkModeState.Off)
+            if (_state != TalkModeState.Off || _activating)
                 return;
+            _activating = true;
         }
 
         _sessionCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
@@ -111,6 +113,10 @@ public sealed class TalkModeController : ITalkModeController, IDisposable
             UnwireEvents();
             _sessionCts?.Dispose();
             _sessionCts = null;
+        }
+        finally
+        {
+            _activating = false;
         }
     }
 

--- a/src/CopilotVoice/Voice/VoiceLiveConfig.cs
+++ b/src/CopilotVoice/Voice/VoiceLiveConfig.cs
@@ -6,7 +6,7 @@ namespace CopilotVoice.Voice;
 public record VoiceLiveConfig(
     string Endpoint,
     string? ApiKey = null,
-    string Model = "gpt-4o-realtime-preview",
+    string Model = "gpt-realtime",
     string Voice = "alloy",
     string SystemInstructions = ""
 );

--- a/src/CopilotVoice/Voice/VoiceLiveSession.cs
+++ b/src/CopilotVoice/Voice/VoiceLiveSession.cs
@@ -72,15 +72,25 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
             audio = Convert.ToBase64String(pcm16Audio.Span)
         });
 
+        if (Interlocked.Increment(ref _audioSendCount) == 1)
+            Console.Error.WriteLine($"[VoiceLive] First audio send ({json.Length} chars): {json[..Math.Min(json.Length, 120)]}...");
+
         await _connection.SendEventAsync(json, ct).ConfigureAwait(false);
     }
+
+    private int _audioSendCount;
 
     public async Task CommitAudioAsync(CancellationToken ct = default)
     {
         ThrowIfDisposed();
 
-        var json = JsonSerializer.Serialize(new { type = "input_audio_buffer.commit" });
-        await _connection.SendEventAsync(json, ct).ConfigureAwait(false);
+        // Trigger response first — the model starts processing the buffered audio immediately
+        var responseJson = JsonSerializer.Serialize(new { type = "response.create" });
+        await _connection.SendEventAsync(responseJson, ct).ConfigureAwait(false);
+
+        // Then commit the buffer (may error with "empty" if response.create already consumed it — benign)
+        var commitJson = JsonSerializer.Serialize(new { type = "input_audio_buffer.commit" });
+        await _connection.SendEventAsync(commitJson, ct).ConfigureAwait(false);
     }
 
     public async Task SendTextAsync(string text, CancellationToken ct = default)
@@ -280,10 +290,18 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
 
                 case "error":
                     Console.Error.WriteLine($"[VoiceLive] Error event: {json[..Math.Min(json.Length, 500)]}");
-                    if (root.TryGetProperty("error", out var errorObj) &&
-                        errorObj.TryGetProperty("message", out var errorMsg))
+                    if (root.TryGetProperty("error", out var errorObj))
                     {
-                        ErrorReceived?.Invoke(errorMsg.GetString() ?? "Unknown error");
+                        // Ignore benign commit-empty error — response.create already triggered processing
+                        var code = errorObj.TryGetProperty("code", out var codeProp) ? codeProp.GetString() : null;
+                        if (code == "input_audio_buffer_commit_empty")
+                        {
+                            Console.Error.WriteLine("[VoiceLive] Ignoring benign commit-empty error (response.create already sent)");
+                            break;
+                        }
+
+                        var msg = errorObj.TryGetProperty("message", out var errorMsg) ? errorMsg.GetString() : "Unknown error";
+                        ErrorReceived?.Invoke(msg ?? "Unknown error");
                     }
                     else
                     {
@@ -319,6 +337,7 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
         );
 
         var json = SerializeSessionUpdate(update);
+        Console.Error.WriteLine($"[VoiceLive] Sending session.update: {json[..Math.Min(json.Length, 400)]}");
         await _connection.SendEventAsync(json, ct).ConfigureAwait(false);
     }
 

--- a/src/CopilotVoice/Voice/VoiceLiveSession.cs
+++ b/src/CopilotVoice/Voice/VoiceLiveSession.cs
@@ -84,13 +84,12 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
     {
         ThrowIfDisposed();
 
-        // Trigger response first — the model starts processing the buffered audio immediately
-        var responseJson = JsonSerializer.Serialize(new { type = "response.create" });
-        await _connection.SendEventAsync(responseJson, ct).ConfigureAwait(false);
-
-        // Then commit the buffer (may error with "empty" if response.create already consumed it — benign)
+        // Commit the audio buffer first, then trigger response
         var commitJson = JsonSerializer.Serialize(new { type = "input_audio_buffer.commit" });
         await _connection.SendEventAsync(commitJson, ct).ConfigureAwait(false);
+
+        var responseJson = JsonSerializer.Serialize(new { type = "response.create" });
+        await _connection.SendEventAsync(responseJson, ct).ConfigureAwait(false);
     }
 
     public async Task SendTextAsync(string text, CancellationToken ct = default)
@@ -252,7 +251,10 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
                 return;
 
             var type = typeProp.GetString();
-            Console.Error.WriteLine($"[VoiceLive] Event: {type}");
+
+            // Only log non-streaming events (skip noisy audio/transcript deltas)
+            if (type is not "response.audio.delta" and not "response.audio_transcript.delta")
+                Console.Error.WriteLine($"[VoiceLive] Event: {type}");
 
             switch (type)
             {
@@ -331,7 +333,7 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
             Modalities: new[] { "audio", "text" },
             Voice: _config.Voice,
             Instructions: string.IsNullOrEmpty(_config.SystemInstructions)
-                ? "You are a voice interface for GitHub Copilot CLI. Help the developer by executing commands, reading files, and providing context about their coding session."
+                ? "You are a voice interface for GitHub Copilot CLI. Always respond in English. Help the developer by executing commands, reading files, and providing context about their coding session. Keep responses concise — 1-2 sentences spoken aloud."
                 : _config.SystemInstructions,
             Tools: tools
         );
@@ -361,6 +363,7 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
                 instructions = update.Instructions,
                 input_audio_format = update.InputAudioFormat,
                 output_audio_format = update.OutputAudioFormat,
+                turn_detection = (object?)null, // Disable server-side VAD — we control turns via push-to-talk
                 tools,
                 tool_choice = update.ToolChoice
             }

--- a/src/CopilotVoice/Voice/VoiceLiveSession.cs
+++ b/src/CopilotVoice/Voice/VoiceLiveSession.cs
@@ -242,6 +242,7 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
                 return;
 
             var type = typeProp.GetString();
+            Console.Error.WriteLine($"[VoiceLive] Event: {type}");
 
             switch (type)
             {
@@ -278,6 +279,7 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
                     break;
 
                 case "error":
+                    Console.Error.WriteLine($"[VoiceLive] Error event: {json[..Math.Min(json.Length, 500)]}");
                     if (root.TryGetProperty("error", out var errorObj) &&
                         errorObj.TryGetProperty("message", out var errorMsg))
                     {
@@ -349,6 +351,19 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
     internal static Uri BuildWebSocketUri(VoiceLiveConfig config)
     {
         var endpoint = config.Endpoint.TrimEnd('/');
+
+        // If the endpoint already contains the full realtime URL path, use it directly
+        if (endpoint.Contains("/openai/realtime", StringComparison.OrdinalIgnoreCase))
+        {
+            if (endpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+                endpoint = "wss://" + endpoint[8..];
+            return new Uri(endpoint);
+        }
+
+        // Azure Realtime API requires the openai.azure.com domain, not cognitiveservices.azure.com
+        endpoint = endpoint.Replace(".cognitiveservices.azure.com", ".openai.azure.com",
+            StringComparison.OrdinalIgnoreCase);
+
         // Strip https:// and replace with wss://
         if (endpoint.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
             endpoint = "wss://" + endpoint[8..];
@@ -356,7 +371,7 @@ public sealed class VoiceLiveSession : IVoiceLiveSession
             endpoint = "wss://" + endpoint;
 
         return new Uri(
-            $"{endpoint}/openai/realtime?api-version=2025-04-01-preview&deployment={config.Model}");
+            $"{endpoint}/openai/realtime?api-version=2024-10-01-preview&deployment={config.Model}");
     }
 
     internal static IDictionary<string, string> BuildHeaders(VoiceLiveConfig config)

--- a/src/CopilotVoice/Voice/WebSocketConnection.cs
+++ b/src/CopilotVoice/Voice/WebSocketConnection.cs
@@ -11,6 +11,7 @@ internal sealed class WebSocketConnection : IRealtimeConnection
 {
     private ClientWebSocket? _ws;
     private const int ReceiveBufferSize = 16 * 1024; // 16 KB
+    private readonly SemaphoreSlim _sendLock = new(1, 1);
 
     public bool IsConnected => _ws?.State == WebSocketState.Open;
 
@@ -29,12 +30,20 @@ internal sealed class WebSocketConnection : IRealtimeConnection
         if (_ws is null || _ws.State != WebSocketState.Open)
             throw new InvalidOperationException("WebSocket is not connected.");
 
-        var bytes = Encoding.UTF8.GetBytes(eventJson);
-        await _ws.SendAsync(
-            bytes.AsMemory(),
-            WebSocketMessageType.Text,
-            endOfMessage: true,
-            ct).ConfigureAwait(false);
+        await _sendLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var bytes = Encoding.UTF8.GetBytes(eventJson);
+            await _ws.SendAsync(
+                bytes.AsMemory(),
+                WebSocketMessageType.Text,
+                endOfMessage: true,
+                ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            _sendLock.Release();
+        }
     }
 
     public async IAsyncEnumerable<string> ReceiveEventsAsync(


### PR DESCRIPTION
Fixes discovered during live testing of the v2 voice pipeline.

## Changes

### Audio sample rate (16kHz → 24kHz)
Azure Realtime API `pcm16` format expects **24kHz** audio (not 16kHz). Updated MicCapture and AudioPlayer:
- SampleRate: 16000 → 24000
- FramesPerBuffer: 1600 → 2400 (keeps 100ms chunks)

### WebSocket send serialization
`ClientWebSocket.SendAsync` is not thread-safe for concurrent calls. PortAudio callback fires every 100ms, launching concurrent `SendAudioAsync` tasks that deadlocked the WebSocket. Added `SemaphoreSlim` to serialize sends.

### Endpoint URL handling
- Auto-detect full realtime URL in `AZURE_VOICELIVE_ENDPOINT` (prevents path doubling)
- Auto-replace `.cognitiveservices.azure.com` with `.openai.azure.com`

### Talk Mode activation race
Added `_activating` flag to prevent PTT from triggering during async Talk Mode activation.

### Default model name
Changed from `gpt-4o-realtime-preview` to `gpt-realtime` to match typical Azure deployment names.

## Testing
Live-tested with Azure AI Foundry gpt-realtime deployment. Mic captures, audio streams to API, session connects. Further testing in progress.

Part of epic #59